### PR TITLE
migrating Memory Cache and Predis Cache to psr16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,6 @@ This package follows [semver](http://semver.org/) versioning.
     - When the cache package is updated any cache keys using the before mentioned values will throw `Psr\SimpleCache\InvalidArgumentExceptions`. 
     - Cache Key delimiters now default to `.` since `:` is now an invalid key character
         - When the cache package is updated all old keys using the default delimiter will be invalid.
-### Changed
-- Predis Clients now append a "CacheGeneration" number to the salted keys to provide simple cache invalidation with `PredisHandler::clear`
 
 ## [3.0.0] - 2016-11-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,24 @@ All notable changes to this project will be documented in this file. See [keepac
 
 This package follows [semver](http://semver.org/) versioning.
 
+## [3.1.0] - 2017-1-23
+### Added
+- All cache implementations now implement [PSR16](http://www.php-fig.org/psr/psr-16/)
+    - This adds the following methods `delete`, `clear`, `getMultiple`, `setMultiple`, `deleteMultiple`, and `has`
+    - `Cache::get` now has an optional second argument `$default` which sets the return value in case of a cache miss
+    - Cache TTL's can now be `null`, `int`, `DateInterval`, or [TimeInterval](https://github.com/quickenloans-mcp/mcp-common#timeinterval)
+        - [TimeInterval](https://github.com/quickenloans-mcp/mcp-common#timeinterval) is not part of the PSR16 spec but we will support it here
+          to encourage it's use and keep the expectation of interoperability in [MCP](https://github.com/quickenloans-mcp) packages of [MCP Common's](https://github.com/quickenloans-mcp/mcp-common)
+          datatypes.
+    - New `InvalidArgumentException` as required by [PSR16's InvalidArgumentException](http://www.php-fig.org/psr/psr-16/#invalidargumentexception)
+    - Added `CacheInputValidationTrait` which is used by the cache implementations to detect invalid keys
+- **[BC WARNING]** According to [PSR16](http://www.php-fig.org/psr/psr-16/) `{}()/\@:` are invalid cache key characters
+    - When the cache package is updated any cache keys using the before mentioned values will throw `Psr\SimpleCache\InvalidArgumentExceptions`. 
+    - Cache Key delimiters now default to `.` since `:` is now an invalid key character
+        - When the cache package is updated all old keys using the default delimiter will be invalid.
+### Changed
+- Predis Clients now append a "CacheGeneration" number to the salted keys to provide simple cache invalidation with `PredisHandler::clear`
+
 ## [3.0.0] - 2016-11-21
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,12 @@
         "psr-4": { "QL\\MCP\\Cache\\": "src" }
     },
 
+    "provide": {
+        "psr/simple-cache-implementation": "~1.0"
+    },
+
     "require": {
+        "psr/simple-cache": "~1.0",
         "php": "~5.6 || ~7.0",
         "ql/mcp-common": "~1.0"
     },

--- a/src/APCCache.php
+++ b/src/APCCache.php
@@ -136,6 +136,7 @@ class APCCache implements CacheInterface, PSR16CacheInterface
     public function delete($key)
     {
         $this->validateKey($key);
+        $key = $this->salted($key, $this->suffix);
 
         apcu_delete($key);
 
@@ -159,13 +160,13 @@ class APCCache implements CacheInterface, PSR16CacheInterface
         $keys = $this->validateIterable($keys);
         $saltedKeys = array_map(function($key){
             $this->validateKey($key);
-            $this->salted($key, $this->suffix);
+            return $this->salted($key, $this->suffix);
         }, $keys);
 
         $responses = [];
         for ($i = 0; $i < count($keys); $i++) {
             $responseKey = $keys[$i];
-            $responseValue = $this->get($saltedKeys[$i]);
+            $responseValue = $this->get($saltedKeys[$i], $default);
 
             $responses[$responseKey] = $responseValue;
         }
@@ -192,7 +193,7 @@ class APCCache implements CacheInterface, PSR16CacheInterface
         $values = $this->validateIterable($values);
         $saltedKeys = array_map(function ($key) {
             $this->validateKey($key);
-            $this->salted($key, $this->suffix);
+            return $this->salted($key, $this->suffix);
         }, array_keys($values));
 
         $saltedKeysAndValues = array_combine($saltedKeys, array_values($values));
@@ -221,7 +222,7 @@ class APCCache implements CacheInterface, PSR16CacheInterface
         $keys = $this->validateIterable($keys);
         $saltedKeys = array_map(function($key){
             $this->validateKey($key);
-            $this->salted($key, $this->suffix);
+            return $this->salted($key, $this->suffix);
         }, $keys);
 
         foreach ($saltedKeys as $key) {
@@ -249,6 +250,7 @@ class APCCache implements CacheInterface, PSR16CacheInterface
     public function has($key)
     {
         $this->validateKey($key);
+        $key = $this->salted($key, $this->suffix);
 
         return apcu_exists($key);
     }

--- a/src/APCCache.php
+++ b/src/APCCache.php
@@ -7,7 +7,9 @@
 
 namespace QL\MCP\Cache;
 
+use Psr\SimpleCache\CacheInterface as PSR16CacheInterface;
 use QL\MCP\Cache\Item\Item;
+use QL\MCP\Cache\Utility\CacheInputValidationTrait;
 use QL\MCP\Cache\Utility\KeySaltingTrait;
 use QL\MCP\Cache\Utility\MaximumTTLTrait;
 use QL\MCP\Cache\Utility\StampedeProtectionTrait;
@@ -20,11 +22,12 @@ use QL\MCP\Common\Time\Clock;
  * will not expunge any keys until the cache reaches the maximum size. It will also only invalidate after a call to
  * fetch() which means it will return an expired key once before expunging it.
  */
-class APCCache implements CacheInterface
+class APCCache implements CacheInterface, PSR16CacheInterface
 {
     use KeySaltingTrait;
     use MaximumTTLTrait;
     use StampedeProtectionTrait;
+    use CacheInputValidationTrait;
 
     const ERR_APC_NOT_INSTALLED = 'APC must be installed to use this cache.';
 
@@ -65,14 +68,15 @@ class APCCache implements CacheInterface
     /**
      * {@inheritdoc}
      */
-    public function get($key)
+    public function get($key, $default = null)
     {
+        $this->validateKey($key);
         $key = $this->salted($key, $this->suffix);
 
         $item = apcu_fetch($key, $success);
 
         if (!$success || !$item instanceof Item) {
-            return null;
+            return $default;
         }
 
         $now = $this->clock->read();
@@ -86,11 +90,13 @@ class APCCache implements CacheInterface
      */
     public function set($key, $value, $ttl = 0)
     {
+        $this->validateKey($key);
         $key = $this->salted($key, $this->suffix);
 
         // handle deletions
         if ($value === null) {
             apcu_delete($key);
+
             return true;
         }
 
@@ -103,18 +109,147 @@ class APCCache implements CacheInterface
         }
 
         $item = new Item($value, $expiry, $ttl);
+
         return apcu_store($key, $item, $ttl);
     }
 
     /**
      * Clear the cache
      *
-     * WARNING: Nonstandard method.
-     *
      * @return bool
      */
     public function clear()
     {
         return apcu_clear_cache();
+    }
+
+    /**
+     * Delete an item from the cache by its unique key.
+     *
+     * @param string $key The unique cache key of the item to delete.
+     *
+     * @return bool True if the item was successfully removed. False if there was an error.
+     *
+     * @throws \Psr\SimpleCache\InvalidArgumentException
+     *   MUST be thrown if the $key string is not a legal value.
+     */
+    public function delete($key)
+    {
+        $this->validateKey($key);
+
+        apcu_delete($key);
+
+        return true;
+    }
+
+    /**
+     * Obtains multiple cache items by their unique keys.
+     *
+     * @param iterable $keys A list of keys that can obtained in a single operation.
+     * @param mixed $default Default value to return for keys that do not exist.
+     *
+     * @return iterable A list of key => value pairs. Cache keys that do not exist or are stale will have $default as value.
+     *
+     * @throws \Psr\SimpleCache\InvalidArgumentException
+     *   MUST be thrown if $keys is neither an array nor a Traversable,
+     *   or if any of the $keys are not a legal value.
+     */
+    public function getMultiple($keys, $default = null)
+    {
+        $keys = $this->validateIterable($keys);
+        $saltedKeys = array_map(function($key){
+            $this->validateKey($key);
+            $this->salted($key, $this->suffix);
+        }, $keys);
+
+        $responses = [];
+        for ($i = 0; $i < count($keys); $i++) {
+            $responseKey = $keys[$i];
+            $responseValue = $this->get($saltedKeys[$i]);
+
+            $responses[$responseKey] = $responseValue;
+        }
+
+        return $responses;
+    }
+
+    /**
+     * Persists a set of key => value pairs in the cache, with an optional TTL.
+     *
+     * @param iterable $values A list of key => value pairs for a multiple-set operation.
+     * @param null|int|DateInterval $ttl Optional. The TTL value of this item. If no value is sent and
+     *                                      the driver supports TTL then the library may set a default value
+     *                                      for it or let the driver take care of that.
+     *
+     * @return bool True on success and false on failure.
+     *
+     * @throws \Psr\SimpleCache\InvalidArgumentException
+     *   MUST be thrown if $values is neither an array nor a Traversable,
+     *   or if any of the $values are not a legal value.
+     */
+    public function setMultiple($values, $ttl = null)
+    {
+        $values = $this->validateIterable($values);
+        $saltedKeys = array_map(function ($key) {
+            $this->validateKey($key);
+            $this->salted($key, $this->suffix);
+        }, array_keys($values));
+
+        $saltedKeysAndValues = array_combine($saltedKeys, array_values($values));
+
+        foreach ($saltedKeysAndValues as $key => $value) {
+            $this->set($key, $value, $ttl);
+        }
+
+        return true;
+    }
+
+
+    /**
+     * Deletes multiple cache items in a single operation.
+     *
+     * @param iterable $keys A list of string-based keys to be deleted.
+     *
+     * @return bool True if the items were successfully removed. False if there was an error.
+     *
+     * @throws \Psr\SimpleCache\InvalidArgumentException
+     *   MUST be thrown if $keys is neither an array nor a Traversable,
+     *   or if any of the $keys are not a legal value.
+     */
+    public function deleteMultiple($keys)
+    {
+        $keys = $this->validateIterable($keys);
+        $saltedKeys = array_map(function($key){
+            $this->validateKey($key);
+            $this->salted($key, $this->suffix);
+        }, $keys);
+
+        foreach ($saltedKeys as $key) {
+            $this->delete($key);
+        }
+
+        return true;
+    }
+
+    /**
+     * Determines whether an item is present in the cache.
+     *
+     * NOTE: It is recommended that has() is only to be used for cache warming type purposes
+     * and not to be used within your live applications operations for get/set, as this method
+     * is subject to a race condition where your has() will return true and immediately after,
+     * another script can remove it making the state of your app out of date.
+     *
+     * @param string $key The cache item key.
+     *
+     * @return bool
+     *
+     * @throws \Psr\SimpleCache\InvalidArgumentException
+     *   MUST be thrown if the $key string is not a legal value.
+     */
+    public function has($key)
+    {
+        $this->validateKey($key);
+
+        return apcu_exists($key);
     }
 }

--- a/src/CacheInterface.php
+++ b/src/CacheInterface.php
@@ -9,10 +9,12 @@ namespace QL\MCP\Cache;
 
 /**
  * @api
+ *
+ * @deprecated
  */
 interface CacheInterface
 {
-    const VERSION = '3.0.0';
+    const VERSION = '3.1.0';
 
     /**
      * @param string $key

--- a/src/CachingTrait.php
+++ b/src/CachingTrait.php
@@ -105,7 +105,8 @@ trait CachingTrait
      */
     public function clearCache()
     {
-        if (!$cache = $this->cache() instanceof PSR16CacheInterface) {
+        $cache = $this->cache();
+        if (!$cache instanceof PSR16CacheInterface) {
             return;
         }
 

--- a/src/InvalidArgumentException.php
+++ b/src/InvalidArgumentException.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * @copyright ©2017 Quicken Loans Inc. All rights reserved. Trade Secret,
+ *    Confidential and Proprietary. Any dissemination outside of Quicken Loans
+ *    is strictly prohibited.
+ */
+namespace QL\MCP\Cache;
+
+class InvalidArgumentException extends Exception implements \Psr\SimpleCache\InvalidArgumentException
+{
+}

--- a/src/MemcacheCache.php
+++ b/src/MemcacheCache.php
@@ -8,6 +8,9 @@
 namespace QL\MCP\Cache;
 
 use Memcache;
+use Psr\SimpleCache\CacheInterface as PSR16CacheInterface;
+use QL\MCP\Cache\Utility\CacheInputValidationTrait;
+use QL\MCP\Cache\Utility\MaximumTTLTrait;
 
 /**
  * PHP.NET Docs:
@@ -18,8 +21,11 @@ use Memcache;
  *
  * @internal
  */
-class MemcacheCache implements CacheInterface
+class MemcacheCache implements CacheInterface, PSR16CacheInterface
 {
+    use CacheInputValidationTrait;
+    use MaximumTTLTrait;
+
     /**
      * @var Memcache
      */
@@ -38,9 +44,13 @@ class MemcacheCache implements CacheInterface
      *
      * {@inheritdoc}
      */
-    public function get($key)
+    public function get($key, $default = null)
     {
-        return $this->cache->get($key);
+        $this->validateKey($key);
+
+        $cached = $this->cache->get($key);
+
+        return $cached ? $cached : $default;
     }
 
     /**
@@ -50,12 +60,147 @@ class MemcacheCache implements CacheInterface
      */
     public function set($key, $value, $ttl = 0)
     {
+        $this->validateKey($key);
+
         // handle deletions
         if ($value === null) {
             $this->cache->delete($key);
+
             return true;
         }
 
+        $ttl = $this->determineTTL($ttl);
+
         return $this->cache->set($key, $value, null, $ttl);
+    }
+
+    /**
+     * Delete an item from the cache by its unique key.
+     *
+     * @param string $key The unique cache key of the item to delete.
+     *
+     * @return bool True if the item was successfully removed. False if there was an error.
+     *
+     * @throws \Psr\SimpleCache\InvalidArgumentException
+     *   MUST be thrown if the $key string is not a legal value.
+     */
+    public function delete($key)
+    {
+        $this->validateKey($key);
+        return $this->cache->delete($key);
+    }
+
+    /**
+     * Wipes clean the entire cache's keys.
+     *
+     * @return bool True on success and false on failure.
+     */
+    public function clear()
+    {
+        return $this->cache->flush();
+    }
+
+    /**
+     * Obtains multiple cache items by their unique keys.
+     *
+     * @param iterable $keys A list of keys that can obtained in a single operation.
+     * @param mixed $default Default value to return for keys that do not exist.
+     *
+     * @return iterable A list of key => value pairs. Cache keys that do not exist or are stale will have $default as value.
+     *
+     * @throws \Psr\SimpleCache\InvalidArgumentException
+     *   MUST be thrown if $keys is neither an array nor a Traversable,
+     *   or if any of the $keys are not a legal value.
+     */
+    public function getMultiple($keys, $default = null)
+    {
+        $keys = $this->validateIterable($keys);
+        array_map(function($key) {
+            $this->validateKey($key);
+        }, $keys);
+
+        $responses = [];
+        foreach ($keys as $key) {
+            $cached = $this->cache->get($key);
+
+            if (!$cached) {
+                $cached = $default;
+            }
+
+            $responses[$key] = $cached;
+        }
+
+        return $responses;
+    }
+
+    /**
+     * Persists a set of key => value pairs in the cache, with an optional TTL.
+     *
+     * @param iterable $values A list of key => value pairs for a multiple-set operation.
+     * @param null|int|DateInterval $ttl Optional. The TTL value of this item. If no value is sent and
+     *                                      the driver supports TTL then the library may set a default value
+     *                                      for it or let the driver take care of that.
+     *
+     * @return bool True on success and false on failure.
+     *
+     * @throws \Psr\SimpleCache\InvalidArgumentException
+     *   MUST be thrown if $values is neither an array nor a Traversable,
+     *   or if any of the $values are not a legal value.
+     */
+    public function setMultiple($values, $ttl = null)
+    {
+        $values = $this->validateIterable($values);
+
+        $responses = [];
+        foreach ($values as $key => $value) {
+            $responses[] = $this->set($key, $value, $ttl);
+        }
+
+        return !in_array(false, $responses);
+    }
+
+    /**
+     * Deletes multiple cache items in a single operation.
+     *
+     * @param iterable $keys A list of string-based keys to be deleted.
+     *
+     * @return bool True if the items were successfully removed. False if there was an error.
+     *
+     * @throws \Psr\SimpleCache\InvalidArgumentException
+     *   MUST be thrown if $keys is neither an array nor a Traversable,
+     *   or if any of the $keys are not a legal value.
+     */
+    public function deleteMultiple($keys)
+    {
+        $keys = $this->validateIterable($keys);
+
+        $responses = [];
+        foreach ($keys as $key ) {
+            $responses[] = $this->delete($key);
+        }
+
+        return true;
+    }
+
+    /**
+     * Determines whether an item is present in the cache.
+     *
+     * NOTE: It is recommended that has() is only to be used for cache warming type purposes
+     * and not to be used within your live applications operations for get/set, as this method
+     * is subject to a race condition where your has() will return true and immediately after,
+     * another script can remove it making the state of your app out of date.
+     *
+     * @param string $key The cache item key.
+     *
+     * @return bool
+     *
+     * @throws \Psr\SimpleCache\InvalidArgumentException
+     *   MUST be thrown if the $key string is not a legal value.
+     */
+    public function has($key)
+    {
+        $cached = $this->get($key, null);
+
+        return (bool)$cached;
     }
 }

--- a/src/MemcacheCache.php
+++ b/src/MemcacheCache.php
@@ -115,18 +115,10 @@ class MemcacheCache implements CacheInterface, PSR16CacheInterface
     public function getMultiple($keys, $default = null)
     {
         $keys = $this->validateIterable($keys);
-        array_map(function($key) {
-            $this->validateKey($key);
-        }, $keys);
 
         $responses = [];
         foreach ($keys as $key) {
-            $cached = $this->cache->get($key);
-
-            if (!$cached) {
-                $cached = $default;
-            }
-
+            $cached = $this->get($key, $default);
             $responses[$key] = $cached;
         }
 

--- a/src/MemcachedCache.php
+++ b/src/MemcachedCache.php
@@ -7,10 +7,12 @@
 
 namespace QL\MCP\Cache;
 
+use QL\MCP\Cache\Utility\CacheInputValidationTrait;
 use QL\MCP\Cache\Utility\KeySaltingTrait;
 use QL\MCP\Cache\Utility\MaximumTTLTrait;
 use Memcached;
 use Psr\Log\LoggerInterface;
+use Psr\SimpleCache\CacheInterface as PSR16CacheInterface;
 
 /**
  * PHP.NET Docs:
@@ -26,13 +28,16 @@ use Psr\Log\LoggerInterface;
  *
  * @internal
  */
-class MemcachedCache implements CacheInterface
+class MemcachedCache implements CacheInterface, PSR16CacheInterface
 {
     use KeySaltingTrait;
     use MaximumTTLTrait;
+    use CacheInputValidationTrait;
 
     const ERR_GET = 'Memcached Error : GET : %s';
     const ERR_SET = 'Memcached Error : SET : %s';
+    const ERR_DEL = 'Memcached Error : DEL : %s';
+    const ERR_FLUSH = 'Memcached Error : Error deleting all cache keys : %s';
 
     const UNKNOWN_CODE = '?';
 
@@ -137,12 +142,19 @@ class MemcachedCache implements CacheInterface
     }
 
     /**
-     * @see http://docs.php.net/manual/en/memcached.get.php
+     * Fetches a value from the cache.
      *
-     * {@inheritdoc}
+     * @param string $key The unique key of this item in the cache.
+     * @param mixed $default Default value to return if the key does not exist.
+     *
+     * @return mixed The value of the item from the cache, or $default in case of cache miss.
+     *
+     * @throws \Psr\SimpleCache\InvalidArgumentException
+     *   MUST be thrown if the $key string is not a legal value.
      */
-    public function get($key)
+    public function get($key, $default = null)
     {
+        $this->validateKey($key);
         $key = $this->salted($key, $this->suffix);
 
         $cached = $this->cache->get($key);
@@ -152,19 +164,30 @@ class MemcachedCache implements CacheInterface
             return $cached;
 
         } else if ($code !== Memcached::RES_NOTFOUND) {
-            $this->sendAlert('get', $key, $code);
+            $this->sendAlert(self::ERR_GET, $key, $code);
+            return $default;
         }
 
         return null;
     }
 
     /**
-     * @see http://docs.php.net/manual/en/memcached.set.php
+     * Persists data in the cache, uniquely referenced by a key with an optional expiration TTL time.
      *
-     * {@inheritdoc}
+     * @param string $key The key of the item to store.
+     * @param mixed $value The value of the item to store, must be serializable.
+     * @param null|int|DateInterval $ttl Optional. The TTL value of this item. If no value is sent and
+     *                                     the driver supports TTL then the library may set a default value
+     *                                     for it or let the driver take care of that.
+     *
+     * @return bool True on success and false on failure.
+     *
+     * @throws \Psr\SimpleCache\InvalidArgumentException
+     *   MUST be thrown if the $key string is not a legal value.
      */
     public function set($key, $value, $ttl = 0)
     {
+        $this->validateKey($key);
         $key = $this->salted($key, $this->suffix);
 
         // handle deletions
@@ -183,8 +206,201 @@ class MemcachedCache implements CacheInterface
             return true;
         }
 
-        $this->sendAlert('set', $key, $code);
+        $this->sendAlert(self::ERR_SET, $key, $code);
         return false;
+    }
+
+    /**
+     * Delete an item from the cache by its unique key.
+     *
+     * @param string $key The unique cache key of the item to delete.
+     *
+     * @return bool True if the item was successfully removed. False if there was an error.
+     *
+     * @throws \Psr\SimpleCache\InvalidArgumentException
+     *   MUST be thrown if the $key string is not a legal value.
+     */
+    public function delete($key)
+    {
+        $this->validateKey($key);
+        $key = $this->salted($key, $this->suffix);
+
+        $this->cache->delete($key);
+        $code = $this->cache->getResultCode();
+
+        if ($code === Memcached::RES_SUCCESS) {
+            return true;
+        }
+
+        $this->sendAlert(self::ERR_DEL, $key, $code);
+        return false;
+    }
+
+    /**
+     * Wipes clean the entire cache's keys.
+     *
+     * @return bool True on success and false on failure.
+     */
+    public function clear()
+    {
+        $this->cache->flush();
+        $code = $this->cache->getResultCode();
+
+        if ($code === Memcached::RES_SUCCESS) {
+            return true;
+        }
+
+        $this->sendAlert(self::ERR_FLUSH, '', $code);
+        return false;
+    }
+
+    /**
+     * Obtains multiple cache items by their unique keys.
+     *
+     * @param iterable $keys A list of keys that can obtained in a single operation.
+     * @param mixed $default Default value to return for keys that do not exist.
+     *
+     * @return iterable A list of key => value pairs. Cache keys that do not exist or are stale will have $default as value.
+     *
+     * @throws \Psr\SimpleCache\InvalidArgumentException
+     *   MUST be thrown if $keys is neither an array nor a Traversable,
+     *   or if any of the $keys are not a legal value.
+     */
+    public function getMultiple($keys, $default = null)
+    {
+        $keys = $this->validateIterable($keys);
+
+        //validate and salt
+        $validAndSaltedKeys = array_map(function($key){
+            $this->validateKey($key);
+            return $this->salted($key, $this->suffix);
+        }, $keys);
+
+        //responses only has the keys that did exist in the cache
+        $responses = $this->cache->getMulti($validAndSaltedKeys);
+        $code = $this->cache->getResultCode();
+
+        $missingKeys = array_diff($validAndSaltedKeys, array_keys($responses));
+
+        $saltedKeysToUnsaltedKeys = array_combine($validAndSaltedKeys, $keys);
+
+        //fill in missing keys with default
+        foreach ($missingKeys as $missingKey) {
+            $responses[$missingKey] = $default;
+        }
+
+        //change salted key responses to un salted responses
+        $unsaltedResponse = [];
+        foreach ($responses as $saltedKey => $returnValue) {
+            $unSaltedKey = $saltedKeysToUnsaltedKeys[$saltedKey];
+            $unsaltedResponse[$unSaltedKey] = $returnValue;
+        }
+
+        if ($code === Memcached::RES_SUCCESS) {
+            return $unsaltedResponse;
+        }
+
+        $this->sendAlert(self::ERR_GET, 'Keys: ' . implode(" ", $keys), $code);
+        return [];
+    }
+
+    /**
+     * Persists a set of key => value pairs in the cache, with an optional TTL.
+     *
+     * @param iterable $values A list of key => value pairs for a multiple-set operation.
+     * @param null|int|DateInterval $ttl Optional. The TTL value of this item. If no value is sent and
+     *                                      the driver supports TTL then the library may set a default value
+     *                                      for it or let the driver take care of that.
+     *
+     * @return bool True on success and false on failure.
+     *
+     * @throws \Psr\SimpleCache\InvalidArgumentException
+     *   MUST be thrown if $values is neither an array nor a Traversable,
+     *   or if any of the $values are not a legal value.
+     */
+    public function setMultiple($values, $ttl = null)
+    {
+        $values = $this->validateIterable($values);
+
+        //validate and salt
+        $validAndSaltedKeys = array_map(function($key){
+            $this->validateKey($key);
+            return $this->salted($key, $this->suffix);
+        }, array_keys($values));
+
+        $values = array_combine($validAndSaltedKeys, array_values($values));
+
+        // Resolve the TTL to use
+        $ttl = $this->determineTTL($ttl);
+
+        $this->cache->setMulti($values, $ttl);
+        $code = $this->cache->getResultCode();
+
+        if ($code === Memcached::RES_SUCCESS) {
+            return true;
+        }
+
+        $this->sendAlert(self::ERR_SET, 'Keys: ' . implode(" ", array_keys($values)), $code);
+        return false;
+
+    }
+
+    /**
+     * Deletes multiple cache items in a single operation.
+     *
+     * @param iterable $keys A list of string-based keys to be deleted.
+     *
+     * @return bool True if the items were successfully removed. False if there was an error.
+     *
+     * @throws \Psr\SimpleCache\InvalidArgumentException
+     *   MUST be thrown if $keys is neither an array nor a Traversable,
+     *   or if any of the $keys are not a legal value.
+     */
+    public function deleteMultiple($keys)
+    {
+        $keys = $this->validateIterable($keys);
+
+        //validate and salt
+        $validAndSaltedKeys = array_map(function($key){
+            $this->validateKey($key);
+            return $this->salted($key, $this->suffix);
+        }, $keys);
+
+        $this->cache->deleteMulti($validAndSaltedKeys);
+        $code = $this->cache->getResultCode();
+
+        if ($code === Memcached::RES_SUCCESS) {
+            return true;
+        }
+
+        $this->sendAlert(self::DELETE_MULTI, 'Keys: ' . implode(" ", $keys), $code);
+        return false;
+    }
+
+    /**
+     * Determines whether an item is present in the cache.
+     *
+     * NOTE: It is recommended that has() is only to be used for cache warming type purposes
+     * and not to be used within your live applications operations for get/set, as this method
+     * is subject to a race condition where your has() will return true and immediately after,
+     * another script can remove it making the state of your app out of date.
+     *
+     * @param string $key The cache item key.
+     *
+     * @return bool
+     *
+     * @throws \Psr\SimpleCache\InvalidArgumentException
+     *   MUST be thrown if the $key string is not a legal value.
+     */
+    public function has($key)
+    {
+        $this->validateKey($key);
+        $key = $this->salted($key, $this->suffix);
+
+        $this->cache->get($key);
+        $resultCode = $this->cache->getResultCode();
+
+        return $resultCode === Memcached::RES_SUCCESS;
     }
 
     /**
@@ -212,13 +428,12 @@ class MemcachedCache implements CacheInterface
      *
      * @return void
      */
-    private function sendAlert($type, $key, $code)
+    private function sendAlert($template, $key, $code)
     {
         if (!$this->logger) {
             return;
         }
 
-        $template = ($type === 'get') ? self::ERR_GET : self::ERR_SET;
         $priority = ($code === Memcached::RES_NO_SERVERS) ? 'error' : 'warning';
         $code = $this->getHumanResultCode($code);
 

--- a/src/MemcachedCache.php
+++ b/src/MemcachedCache.php
@@ -47,7 +47,7 @@ class MemcachedCache implements CacheInterface, PSR16CacheInterface
      * @var string
      */
     const PREFIX = 'mcp-cache-' . CacheInterface::VERSION;
-    const DELIMITER = ':';
+    const DELIMITER = '.';
 
     /**
      * @var Memcached

--- a/src/MemoryCache.php
+++ b/src/MemoryCache.php
@@ -7,13 +7,18 @@
 
 namespace QL\MCP\Cache;
 
+use QL\MCP\Cache\CacheInterface as MCPCacheInterface;
+use Psr\SimpleCache\CacheInterface as PSR16CacheInterface;
 use QL\MCP\Cache\Item\Item;
+use QL\MCP\Cache\Utility\CacheInputValidationTrait;
 
 /**
  * @internal
  */
-class MemoryCache implements CacheInterface
+class MemoryCache implements PSR16CacheInterface, MCPCacheInterface
 {
+    use CacheInputValidationTrait;
+
     /**
      * @var Item[]
      */
@@ -25,25 +30,168 @@ class MemoryCache implements CacheInterface
     }
 
     /**
-     * {@inheritdoc}
+     * Fetches a value from the cache.
+     *
+     * @param string $key The unique key of this item in the cache.
+     * @param mixed $default Default value to return if the key does not exist.
+     *
+     * @return mixed The value of the item from the cache, or $default in case of cache miss.
+     *
+     * @throws \Psr\SimpleCache\InvalidArgumentException
+     *   MUST be thrown if the $key string is not a legal value.
      */
-    public function get($key)
+    public function get($key, $default = null)
     {
+        $this->validateKey($key);
+
         if (isset($this->cache[$key])) {
             return $this->cache[$key]->data();
         }
 
-        return null;
+        return $default;
     }
 
     /**
-     * $ttl is ignored. If your data is living that long in memory, you got issues.
+     * Persists data in the cache, uniquely referenced by a key with an optional expiration TTL time.
      *
-     * {@inheritdoc}
+     * @param string $key The key of the item to store.
+     * @param mixed $value The value of the item to store, must be serializable.
+     * @param null|int|DateInterval $ttl Optional. The TTL value of this item. If no value is sent and
+     *                                     the driver supports TTL then the library may set a default value
+     *                                     for it or let the driver take care of that.
+     *
+     * @return bool True on success and false on failure.
+     *
+     * @throws \Psr\SimpleCache\InvalidArgumentException
+     *   MUST be thrown if the $key string is not a legal value.
      */
-    public function set($key, $value, $ttl = 0)
+    public function set($key, $value, $ttl = null)
     {
+        $this->validateKey($key);
+
         $this->cache[$key] = new Item($value);
         return true;
+    }
+
+    /**
+     * Delete an item from the cache by its unique key.
+     *
+     * @param string $key The unique cache key of the item to delete.
+     *
+     * @return bool True if the item was successfully removed. False if there was an error.
+     *
+     * @throws \Psr\SimpleCache\InvalidArgumentException
+     *   MUST be thrown if the $key string is not a legal value.
+     */
+    public function delete($key)
+    {
+        $this->validateKey($key);
+
+        unset($this->cache[$key]);
+        return true;
+    }
+
+    /**
+     * Wipes clean the entire cache's keys.
+     *
+     * @return bool True on success and false on failure.
+     */
+    public function clear()
+    {
+        $this->cache = [];
+        return true;
+    }
+
+    /**
+     * Obtains multiple cache items by their unique keys.
+     *
+     * @param iterable $keys A list of keys that can obtained in a single operation.
+     * @param mixed $default Default value to return for keys that do not exist.
+     *
+     * @return iterable A list of key => value pairs. Cache keys that do not exist or are stale will have $default as value.
+     *
+     * @throws \Psr\SimpleCache\InvalidArgumentException
+     *   MUST be thrown if $keys is neither an array nor a Traversable,
+     *   or if any of the $keys are not a legal value.
+     */
+    public function getMultiple($keys, $default = null)
+    {
+        $this->validateIterable($keys);
+
+        $cacheData = [];
+        foreach ($keys as $key) {
+            $cacheData[$key] = $this->get($key, $default);
+        }
+
+        return $cacheData;
+    }
+
+    /**
+     * Persists a set of key => value pairs in the cache, with an optional TTL.
+     *
+     * @param iterable $values A list of key => value pairs for a multiple-set operation.
+     * @param null|int|DateInterval $ttl Optional. The TTL value of this item. If no value is sent and
+     *                                      the driver supports TTL then the library may set a default value
+     *                                      for it or let the driver take care of that.
+     *
+     * @return bool True on success and false on failure.
+     *
+     * @throws \Psr\SimpleCache\InvalidArgumentException
+     *   MUST be thrown if $values is neither an array nor a Traversable,
+     *   or if any of the $values are not a legal value.
+     */
+    public function setMultiple($values, $ttl = null)
+    {
+        $this->validateIterable($values);
+
+        foreach ($values as $key => $value) {
+            $this->set($key, $value);
+        }
+
+        return true;
+    }
+
+    /**
+     * Deletes multiple cache items in a single operation.
+     *
+     * @param iterable $keys A list of string-based keys to be deleted.
+     *
+     * @return bool True if the items were successfully removed. False if there was an error.
+     *
+     * @throws \Psr\SimpleCache\InvalidArgumentException
+     *   MUST be thrown if $keys is neither an array nor a Traversable,
+     *   or if any of the $keys are not a legal value.
+     */
+    public function deleteMultiple($keys)
+    {
+        $this->validateIterable($keys);
+
+        foreach ($keys as $key) {
+            $this->delete($key);
+        }
+
+        return true;
+    }
+
+    /**
+     * Determines whether an item is present in the cache.
+     *
+     * NOTE: It is recommended that has() is only to be used for cache warming type purposes
+     * and not to be used within your live applications operations for get/set, as this method
+     * is subject to a race condition where your has() will return true and immediately after,
+     * another script can remove it making the state of your app out of date.
+     *
+     * @param string $key The cache item key.
+     *
+     * @return bool
+     *
+     * @throws \Psr\SimpleCache\InvalidArgumentException
+     *   MUST be thrown if the $key string is not a legal value.
+     */
+    public function has($key)
+    {
+        $this->validateKey($key);
+
+        return isset($this->cache[$key]);
     }
 }

--- a/src/PredisCache.php
+++ b/src/PredisCache.php
@@ -29,7 +29,7 @@ class PredisCache implements PSR16CacheInterface, MCPCacheInterface
      * @var string
      */
     const PREFIX = 'mcp-cache-' . CacheInterface::VERSION;
-    const DELIMITER = ':';
+    const DELIMITER = '.';
 
     /**
      * @var client

--- a/src/PredisCache.php
+++ b/src/PredisCache.php
@@ -7,17 +7,21 @@
 
 namespace QL\MCP\Cache;
 
+use Predis\Client;
+use Psr\SimpleCache\CacheInterface as PSR16CacheInterface;
+use QL\MCP\Cache\CacheInterface as MCPCacheInterface;
+use QL\MCP\Cache\Utility\CacheInputValidationTrait;
 use QL\MCP\Cache\Utility\KeySaltingTrait;
 use QL\MCP\Cache\Utility\MaximumTTLTrait;
-use Predis\Client;
 
 /**
  * @internal
  */
-class PredisCache implements CacheInterface
+class PredisCache implements PSR16CacheInterface, MCPCacheInterface
 {
     use KeySaltingTrait;
     use MaximumTTLTrait;
+    use CacheInputValidationTrait;
 
     /**
      * Properties read and used by the salting trait.
@@ -26,6 +30,7 @@ class PredisCache implements CacheInterface
      */
     const PREFIX = 'mcp-cache-' . CacheInterface::VERSION;
     const DELIMITER = ':';
+    const GENERATION_KEY = 'mcp-cache-generation-' . CacheInterface::VERSION;
 
     /**
      * @var client
@@ -36,6 +41,12 @@ class PredisCache implements CacheInterface
      * @var string|null
      */
     private $suffix;
+
+    /**
+     * @var int
+     */
+    private $cacheGeneration = 1;
+
 
     /**
      * An optional suffix can be provided which will be appended to the key
@@ -49,55 +60,273 @@ class PredisCache implements CacheInterface
     {
         $this->predis = $client;
         $this->suffix = $suffix;
+        $this->setStoredCacheGeneration();
     }
 
     /**
-     * This cacher performs serialization and unserialization. All string responses from redis will be unserialized.
+     * Fetches a value from the cache.
      *
-     * For this reason, only mcp cachers should attempt to retrieve data cached by mcp cachers.
+     * @param string $key The unique key of this item in the cache.
+     * @param mixed $default Default value to return if the key does not exist.
      *
-     * {@inheritdoc}
+     * @return mixed The value of the item from the cache, or $default in case of cache miss.
+     *
+     * @throws \Psr\SimpleCache\InvalidArgumentException
+     *   MUST be thrown if the $key string is not a legal value.
      */
-    public function get($key)
+    public function get($key, $default = null)
     {
-        $key = $this->salted($key, $this->suffix);
+        $this->validateKey($key);
+        $key = $this->salted($key, $this->suffix, $this->cacheGeneration);
 
         $raw = $this->predis->get($key);
 
-        // every response should be a php serialized string.
-        // values not matching this pattern will explode.
-        // missing data should return null, which is not unserialized.
-        $value = (is_string($raw)) ? unserialize($raw) : $raw;
+        if ($raw === null) {
+            return $default;
+        }
 
-        return $value;
+        return (is_string($raw) ? unserialize($raw) : $raw);
     }
 
     /**
-     * {@inheritdoc}
+     * Persists data in the cache, uniquely referenced by a key with an optional expiration TTL time.
+     *
+     * @param string $key The key of the item to store.
+     * @param mixed $value The value of the item to store, must be serializable.
+     * @param null|int|DateInterval $ttl Optional. The TTL value of this item. If no value is sent and
+     *                                     the driver supports TTL then the library may set a default value
+     *                                     for it or let the driver take care of that.
+     *
+     * @return bool True on success and false on failure.
+     *
+     * @throws \Psr\SimpleCache\InvalidArgumentException
+     *   MUST be thrown if the $key string is not a legal value.
      */
-    public function set($key, $value, $ttl = 0)
+    public function set($key, $value, $ttl = null)
     {
-        $key = $this->salted($key, $this->suffix);
+        $this->validateKey($key);
+        $key = $this->salted($key, $this->suffix, $this->cacheGeneration);
 
-        // handle deletions
+        /*
+         * handle deletions
+         *
+         * this is not a part of the PSR16 spec but we are going to keep it here to keep
+         * backward compatibility with the MCPCacheInterface
+         */
         if ($value === null) {
             $this->predis->del($key);
+
             return true;
         }
 
         $value = serialize($value);
-
         // Resolve the TTL to use
         $ttl = $this->determineTTL($ttl);
 
         // set with expiration
         if ($ttl > 0) {
             $this->predis->setex($key, $ttl, $value);
+
             return true;
         }
 
         // set with no expiration
         $this->predis->set($key, $value);
+
         return true;
+    }
+
+    /**
+     * Delete an item from the cache by its unique key.
+     *
+     * @param string $key The unique cache key of the item to delete.
+     *
+     * @return bool True if the item was successfully removed. False if there was an error.
+     *
+     * @throws \Psr\SimpleCache\InvalidArgumentException
+     *   MUST be thrown if the $key string is not a legal value.
+     */
+    public function delete($key)
+    {
+        $this->validateKey($key);
+        $key = $this->salted($key, $this->suffix, $this->cacheGeneration);
+
+        $this->predis->del($key);
+
+        return true;
+    }
+
+    /**
+     * Wipes clean the entire cache's keys.
+     *
+     * @return bool True on success and false on failure.
+     */
+    public function clear()
+    {
+        $this->setCacheGeneration($this->cacheGeneration + 1);
+
+        return true;
+    }
+
+    /**
+     * Obtains multiple cache items by their unique keys.
+     *
+     * @param iterable $keys A list of keys that can obtained in a single operation.
+     * @param mixed $default Default value to return for keys that do not exist.
+     *
+     * @return iterable A list of key => value pairs. Cache keys that do not exist or are stale will have $default as value.
+     *
+     * @throws \Psr\SimpleCache\InvalidArgumentException
+     *   MUST be thrown if $keys is neither an array nor a Traversable,
+     *   or if any of the $keys are not a legal value.
+     */
+    public function getMultiple($keys, $default = null)
+    {
+        //val
+        $keys = $this->validateIterable($keys);
+        $saltedKeys = $this->validateAndSaltKeys($keys);
+
+        /**
+         * 0 indexed array responses but guaranteed to be in the correct order
+         */
+        $response = $this->predis->mget($saltedKeys);
+
+        //replace null values with passed default
+        $replacedValues = array_map(function ($raw) use ($default) {
+            if ($raw === null) {
+                return $default;
+            }
+
+            return (is_string($raw) ? unserialize($raw) : $raw);
+        }, $response);
+
+        return array_combine($keys, $replacedValues);
+    }
+
+    /**
+     * Persists a set of key => value pairs in the cache, with an optional TTL.
+     *
+     * @param iterable $values A list of key => value pairs for a multiple-set operation.
+     * @param null|int|DateInterval $ttl Optional. The TTL value of this item. If no value is sent and
+     *                                      the driver supports TTL then the library may set a default value
+     *                                      for it or let the driver take care of that.
+     *
+     * @return bool True on success and false on failure.
+     *
+     * @throws \Psr\SimpleCache\InvalidArgumentException
+     *   MUST be thrown if $values is neither an array nor a Traversable,
+     *   or if any of the $values are not a legal value.
+     */
+    public function setMultiple($values, $ttl = null)
+    {
+        $values = $this->validateIterable($values);
+        $saltedKeys = $this->validateAndSaltKeys(array_keys($values));
+
+        $serializedValues = array_map("serialize", array_values($values));
+        $saltedKeysWithValues = array_combine($saltedKeys, $serializedValues);
+
+        $ttl = $this->determineTTL($ttl);
+
+        //start redis multi call
+        $this->predis->multi();
+
+        foreach ($saltedKeysWithValues as $key => $value) {
+            $this->set($key, $value, $ttl);
+        }
+
+        //resolve multi call
+        $this->predis->exec();
+
+        return true;
+    }
+
+    /**
+     * Deletes multiple cache items in a single operation.
+     *
+     * @param iterable $keys A list of string-based keys to be deleted.
+     *
+     * @return bool True if the items were successfully removed. False if there was an error.
+     *
+     * @throws \Psr\SimpleCache\InvalidArgumentException
+     *   MUST be thrown if $keys is neither an array nor a Traversable,
+     *   or if any of the $keys are not a legal value.
+     */
+    public function deleteMultiple($keys)
+    {
+        //validate is iteratable or array and return iterable as an array
+        $keys = $this->validateIterable($keys);
+        $saltedKeys = $this->validateAndSaltKeys($keys);
+
+        $this->predis->multi();
+        foreach ($saltedKeys as $key) {
+            $this->predis->del($key);
+        }
+        $this->predis->exec();
+
+        return true;
+    }
+
+    /**
+     * Determines whether an item is present in the cache.
+     *
+     * NOTE: It is recommended that has() is only to be used for cache warming type purposes
+     * and not to be used within your live applications operations for get/set, as this method
+     * is subject to a race condition where your has() will return true and immediately after,
+     * another script can remove it making the state of your app out of date.
+     *
+     * @param string $key The cache item key.
+     *
+     * @return bool
+     *
+     * @throws \Psr\SimpleCache\InvalidArgumentException
+     *   MUST be thrown if the $key string is not a legal value.
+     */
+    public function has($key)
+    {
+        $this->validateKey($key);
+
+        return (bool)$this->predis->exists($key);
+    }
+
+    /**
+     * Querys the cache for the current cache generation if no cache generation is found than
+     * generation 1 is set.
+     */
+    private function setStoredCacheGeneration()
+    {
+        $storedGeneration = $this->predis->get(self::GENERATION_KEY);
+
+        if (!$storedGeneration) {
+            $storedGeneration = 1;
+            $this->setCacheGeneration(1);
+        }
+
+        $this->cacheGeneration = $storedGeneration;
+    }
+
+    /**
+     * Stores the updated cache generation in the cache. This will invalidate all keys
+     * passing the generation in their salts
+     *
+     * @param $cacheGeneration
+     */
+    private function setCacheGeneration($cacheGeneration)
+    {
+        $this->predis->set(self::GENERATION_KEY, $cacheGeneration);
+        $this->cacheGeneration = $cacheGeneration;
+    }
+
+    /**
+     * @param array $keys
+     *
+     * @return array
+     */
+    private function validateAndSaltKeys(array $keys)
+    {
+        array_map(['this', 'validateKey'], $keys);
+
+        return array_map(function ($key) {
+            return $this->salted($key, $this->suffix, $this->cacheGeneration);
+        }, $keys);
     }
 }

--- a/src/Testing/CachingStub.php
+++ b/src/Testing/CachingStub.php
@@ -18,5 +18,6 @@ class CachingStub
         cache as public;
         getFromCache as public;
         setToCache as public;
+        clearCache as public;
     }
 }

--- a/src/Utility/CacheInputValidationTrait.php
+++ b/src/Utility/CacheInputValidationTrait.php
@@ -9,6 +9,9 @@ namespace QL\MCP\Cache\Utility;
 
 use QL\MCP\Cache\InvalidArgumentException;
 
+/**
+ * @internal
+ */
 trait CacheInputValidationTrait
 {
     // 4 backslashes to match one literal back slash seems bananas.

--- a/src/Utility/CacheInputValidationTrait.php
+++ b/src/Utility/CacheInputValidationTrait.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * @copyright ©2017 Quicken Loans Inc. All rights reserved. Trade Secret,
+ *    Confidential and Proprietary. Any dissemination outside of Quicken Loans
+ *    is strictly prohibited.
+ */
+
+namespace QL\MCP\Cache\Utility;
+
+use QL\MCP\Cache\InvalidArgumentException;
+
+trait CacheInputValidationTrait
+{
+    // 4 backslashes to match one literal back slash seems bananas.
+    private $invalidKeyRegex = '/\{|\}|\(|\)|\/|\\\\|\@|:/';
+    private $invalidKeyMsg = 'Cache key: `%s` contains illegal characters -- keys MUST NOT contain any of the following characters: `{}()/\@:`';
+
+    private $invalidIterableMsg = 'Invalid keys: %s Keys should be an array of strings';
+
+    /**
+     * A regex check to make sure that cache keys do not contain any invalid characters
+     *
+     * According to the psr 16 spec keys MUST NOT contain any of the following (not including the ticks) `{}()\/:`
+     *
+     * @param $key
+     *
+     * @return mixed
+     * @throws InvalidArgumentException
+     */
+    private function validateKey($key)
+    {
+        if (preg_match($this->invalidKeyRegex, $key)) {
+            throw new InvalidArgumentException(sprintf($this->invalidKeyMsg, $key));
+        }
+
+        return $key;
+    }
+
+    private function validateIterable($iterable)
+    {
+        if (!$iterable instanceof \Traversable && !is_array($iterable)) {
+            throw new InvalidArgumentException(sprintf($this->invalidIterableMsg, var_export($iterable, true)));
+        }
+
+        return ($iterable instanceof \Traversable) ? iterator_to_array($iterable) : $iterable;
+    }
+}

--- a/src/Utility/KeySaltingTrait.php
+++ b/src/Utility/KeySaltingTrait.php
@@ -20,9 +20,11 @@ trait KeySaltingTrait
      *
      * @param string $key
      * @param string|null $suffix
+     * @param int|string|null $generation
+     *
      * @return string
      */
-    private function salted($key, $suffix = null)
+    private function salted($key, $suffix = null, $generation = null)
     {
         $delimiter = ':';
         if (defined('static::DELIMITER')) {
@@ -33,10 +35,15 @@ trait KeySaltingTrait
             $key = sprintf('%s%s%s', static::PREFIX, $delimiter, $key);
         }
 
+        if ($generation) {
+            $key = sprintf('%s%s%s', $key, $delimiter, (string)$generation);
+        }
+
         if ($suffix) {
             return sprintf('%s%s%s', $key, $delimiter, $suffix);
         }
 
         return $key;
+
     }
 }

--- a/src/Utility/KeySaltingTrait.php
+++ b/src/Utility/KeySaltingTrait.php
@@ -26,7 +26,7 @@ trait KeySaltingTrait
      */
     private function salted($key, $suffix = null)
     {
-        $delimiter = ':';
+        $delimiter = '.';
         if (defined('static::DELIMITER')) {
             $delimiter = static::DELIMITER;
         }

--- a/src/Utility/KeySaltingTrait.php
+++ b/src/Utility/KeySaltingTrait.php
@@ -24,7 +24,7 @@ trait KeySaltingTrait
      *
      * @return string
      */
-    private function salted($key, $suffix = null, $generation = null)
+    private function salted($key, $suffix = null)
     {
         $delimiter = ':';
         if (defined('static::DELIMITER')) {
@@ -33,10 +33,6 @@ trait KeySaltingTrait
 
         if (defined('static::PREFIX')) {
             $key = sprintf('%s%s%s', static::PREFIX, $delimiter, $key);
-        }
-
-        if ($generation) {
-            $key = sprintf('%s%s%s', $key, $delimiter, (string)$generation);
         }
 
         if ($suffix) {

--- a/src/Utility/MaximumTTLTrait.php
+++ b/src/Utility/MaximumTTLTrait.php
@@ -6,6 +6,7 @@
  */
 
 namespace QL\MCP\Cache\Utility;
+use QL\MCP\Common\Time\TimeInterval;
 
 /**
  * Allow a cacher to specify a maximum TTL for cached data.
@@ -40,6 +41,14 @@ trait MaximumTTLTrait
      */
     private function determineTTL($ttl)
     {
+        if ($ttl instanceof TimeInterval) {
+            $ttl = (int) $ttl->format('%s');
+        }
+
+        if ($ttl instanceof \DateInterval) {
+            $ttl = (int) $ttl->format('%s');
+        }
+
         // if no max is set, use the user provided value
         if (!$this->maximumTTL) {
             return $ttl;

--- a/testing/tests/APCCacheTest.php
+++ b/testing/tests/APCCacheTest.php
@@ -10,6 +10,7 @@ namespace QL\MCP\Cache;
 use QL\MCP\Cache\Exception as CacheException;
 use QL\MCP\Common\Time\Clock;
 use PHPUnit_Framework_TestCase;
+use QL\MCP\Common\Time\TimeInterval;
 
 class APCCacheTest extends PHPUnit_Framework_TestCase
 {
@@ -100,7 +101,7 @@ class APCCacheTest extends PHPUnit_Framework_TestCase
     {
         $cache = new APCCache($this->clock);
 
-        $out = $cache->set('a', 'b', 1);
+        $out = $cache->set('a', 'b', new TimeInterval('PT1S'));
         $this->assertEquals(true, $out);
 
         // sleep until expired
@@ -117,7 +118,7 @@ class APCCacheTest extends PHPUnit_Framework_TestCase
         $cache = new APCCache($this->clock);
 
         $cache->setMaximumTtl(1);
-        $out = $cache->set('a', 'b', 10);
+        $out = $cache->set('a', 'b', new \DateInterval('PT1S'));
         $this->assertEquals(true, $out);
 
         // sleep until expired

--- a/testing/tests/CachingTraitTest.php
+++ b/testing/tests/CachingTraitTest.php
@@ -57,6 +57,40 @@ class CachingTraitTest extends PHPUnit_Framework_TestCase
         $caching->setToCache('key', 'data');
     }
 
+    public function testSettingCacheToNonMCPLegacyOrPSR16Errors()
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $cache = 'wrong!';
+
+        $caching = new CachingStub();
+        $caching->setCache($cache);
+    }
+
+    public function testCallingClearCacheWithCacheSetCallsCache()
+    {
+        $cache = Mockery::mock('Psr\SimpleCache\CacheInterface');
+        $cache
+            ->shouldReceive('clear')
+            ->with()
+            ->once();
+
+        $caching = new CachingStub;
+        $caching->setCache($cache);
+
+        $caching->clearCache();
+    }
+
+    public function testCallingClearCacheWithoutPSR16CacheDoesNotblowUp()
+    {
+        $cache = Mockery::mock(CacheInterface::class);
+        $caching = new CachingStub;
+        $caching->setCache($cache);
+
+        $caching->clearCache();
+    }
+
+
     public function testGettingFromCacheWithCacheSetCallsCache()
     {
         $this->cache

--- a/testing/tests/CachingTraitTest.php
+++ b/testing/tests/CachingTraitTest.php
@@ -61,7 +61,7 @@ class CachingTraitTest extends PHPUnit_Framework_TestCase
     {
         $this->cache
             ->shouldReceive('get')
-            ->with('key')
+            ->with('key', null)
             ->once()
             ->andReturn('data2');
 

--- a/testing/tests/MemcacheCacheTest.php
+++ b/testing/tests/MemcacheCacheTest.php
@@ -49,6 +49,22 @@ class MemcacheCacheTest extends PHPUnit_Framework_TestCase
         $this->assertSame('testvalue2', $actual);
     }
 
+    public function testGettingKeyDefault()
+    {
+        $memcache = Mockery::mock(Memcache::CLASS);
+
+        $memcache
+            ->shouldReceive('get')
+            ->with('mykey')
+            ->andReturn(null)
+            ->once();
+
+        $cache = new MemcacheCache($memcache);
+        $actual = $cache->get('mykey', 'testvalue2');
+
+        $this->assertSame('testvalue2', $actual);
+    }
+
     public function testSettingWithExpiration()
     {
         $memcache = Mockery::mock(Memcache::CLASS);
@@ -73,5 +89,158 @@ class MemcacheCacheTest extends PHPUnit_Framework_TestCase
 
         $cache = new MemcacheCache($memcache);
         $cache->set('mykey', null, 600);
+    }
+
+    public function testDeleteCallsWithKey()
+    {
+        $memcache = Mockery::mock(Memcache::CLASS);
+
+        $memcache
+            ->shouldReceive('delete')
+            ->with('mykey')
+            ->once();
+
+        $cache = new MemcacheCache($memcache);
+        $cache->delete('mykey');
+    }
+
+    public function testClearCallsFlush()
+    {
+        $memcache = Mockery::mock(Memcache::CLASS);
+
+        $memcache
+            ->shouldReceive('flush')
+            ->once();
+
+        $cache = new MemcacheCache($memcache);
+        $cache->clear();
+    }
+
+    public function testMultiGetReturnsAndHasDefaultForUnsetKeys()
+    {
+        $memcache = Mockery::mock(Memcache::CLASS);
+
+        $defaultValue = 'defaultValue';
+
+        $cacheData = ['foo' => 'storedValue', 'bar' => null];
+
+        foreach ($cacheData as $expectedKey => $value) {
+            $expectedValue = $value ? $value : $defaultValue;
+            $memcache
+                ->shouldReceive('get')
+                ->with($expectedKey)
+                ->once()
+                ->andReturn($expectedValue);
+        }
+
+
+        $cache = new MemcacheCache($memcache);
+        $response = $cache->getMultiple(['foo', 'bar'], $defaultValue);
+        $this->assertEquals(['foo' => 'storedValue', 'bar' => $defaultValue], $response);
+    }
+
+    public function testSetMultipleReturnsExpected()
+    {
+        $memcache = Mockery::mock(Memcache::CLASS);
+
+        $cacheData = ['foo' => 'bar', 'baz' => 'buz'];
+        foreach ($cacheData as $expectedKey => $expectedValue) {
+            $memcache
+                ->shouldReceive('set')
+                ->with($expectedKey, $expectedValue, null, 10)
+                ->once()
+                ->andReturn(true);
+        }
+
+        $cache = new MemcacheCache($memcache);
+        $cache->setMultiple(['foo' => 'bar', 'baz' => 'buz'], 10);
+    }
+
+    public function testDeleteMultipleReturnsExpected()
+    {
+        $memcache = Mockery::mock(Memcache::CLASS);
+
+        $cacheData = ['foo', 'baz'];
+        foreach ($cacheData as $expectedKey) {
+            $memcache
+                ->shouldReceive('delete')
+                ->with($expectedKey)
+                ->once()
+                ->andReturn(true);
+        }
+
+        $cache = new MemcacheCache($memcache);
+        $cache->deleteMultiple($cacheData);
+    }
+
+    public function testHasReturnsExpected()
+    {
+        $memcache = Mockery::mock(Memcache::CLASS);
+
+        $expectedKey = 'foo';
+
+        $memcache
+            ->shouldReceive('get')
+            ->with($expectedKey)
+            ->once()
+            ->andReturn('as;dlfkajs;');
+
+        $cache = new MemcacheCache($memcache);
+        $response = $cache->has($expectedKey);
+
+        $this->assertTrue(is_bool($response));
+        $this->assertTrue($response);
+    }
+
+    /**
+     * @dataProvider invalidKeyDataProvider
+     */
+    public function testInvalidArgumentExceptionThrownOnRequiredMethods($method, $args)
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $memcache = Mockery::mock(Memcache::CLASS)->shouldIgnoreMissing();
+
+        $cache = new MemcacheCache($memcache);
+
+        $cache->$method(...$args);
+    }
+
+    public function invalidKeyDataProvider()
+    {
+        $invalidKey = '{}()/\\:';
+
+        // returns [$method, []ofMethodArguments]
+        return [
+            ['get', [$invalidKey]],
+            ['set', [$invalidKey, 'foo']],
+            ['delete', [$invalidKey]],
+            ['getMultiple', [[$invalidKey]]],
+            ['setMultiple', [[$invalidKey => 'foo']]],
+            ['deleteMultiple', [[$invalidKey]]],
+            ['has', [$invalidKey]],
+        ];
+    }
+
+    /**
+     * @dataProvider invalidIterableProvider
+     */
+    public function testInvalidIterableThrowsException($method, $args)
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $memcache = Mockery::mock(Memcache::CLASS)->shouldIgnoreMissing();
+
+        $cache = new MemcacheCache($memcache);
+
+        $cache->$method(...$args);
+    }
+
+    public function invalidIterableProvider()
+    {
+        // returns [$method, []ofMethodArguments]
+        return [
+            ['getMultiple', ['notAnIterator']],
+            ['setMultiple', ['notAnIterator']],
+            ['deleteMultiple', ['notAnIterator']],
+        ];
     }
 }

--- a/testing/tests/MemcachedCacheTest.php
+++ b/testing/tests/MemcachedCacheTest.php
@@ -59,12 +59,12 @@ class MemcachedCacheTest extends PHPUnit_Framework_TestCase
         $actual = $cache->get('derp');
 
         $expectedError1 = ['error', 'Memcached Error : SET : RES_NO_SERVERS', [
-            'cacheKey' => sprintf('mcp-cache-%s:derp:suffix', CacheInterface::VERSION),
+            'cacheKey' => sprintf('mcp-cache-%s.derp.suffix', CacheInterface::VERSION),
             'memcacheError' => 'RES_NO_SERVERS'
         ]];
 
         $expectedError2 = ['error', 'Memcached Error : GET : RES_NO_SERVERS', [
-            'cacheKey' => sprintf('mcp-cache-%s:derp:suffix', CacheInterface::VERSION),
+            'cacheKey' => sprintf('mcp-cache-%s.derp.suffix', CacheInterface::VERSION),
             'memcacheError' => 'RES_NO_SERVERS'
         ]];
 
@@ -87,12 +87,12 @@ class MemcachedCacheTest extends PHPUnit_Framework_TestCase
         $actual = $cache->get('derp');
 
         $expectedError1 = ['warning', 'Memcached Error : SET : RES_SERVER_TEMPORARILY_DISABLED', [
-            'cacheKey' => sprintf('mcp-cache-%s:derp', CacheInterface::VERSION),
+            'cacheKey' => sprintf('mcp-cache-%s.derp', CacheInterface::VERSION),
             'memcacheError' => 'RES_SERVER_TEMPORARILY_DISABLED'
         ]];
 
         $expectedError2 = ['warning', 'Memcached Error : GET : RES_SERVER_TEMPORARILY_DISABLED', [
-            'cacheKey' => sprintf('mcp-cache-%s:derp', CacheInterface::VERSION),
+            'cacheKey' => sprintf('mcp-cache-%s.derp', CacheInterface::VERSION),
             'memcacheError' => 'RES_SERVER_TEMPORARILY_DISABLED'
         ]];
 

--- a/testing/tests/MemcachedCacheTest.php
+++ b/testing/tests/MemcachedCacheTest.php
@@ -100,4 +100,34 @@ class MemcachedCacheTest extends PHPUnit_Framework_TestCase
         $this->assertSame($expectedError1, $logger->messages[0]);
         $this->assertSame($expectedError2, $logger->messages[1]);
     }
+
+    /**
+     * @dataProvider invalidKeyDataProvider
+     */
+    public function testInvalidArgumentExceptionThrownOnRequiredMethods($method, $args)
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $logger = new MemoryLogger;
+
+        $memcached = new Memcached;
+        $cache = new MemcachedCache($memcached, 'suffix', $logger);
+
+        $cache->$method(...$args);
+    }
+
+    public function invalidKeyDataProvider()
+    {
+        $invalidKey = '{}()/\\:';
+
+        // returns [$method, []ofMethodArguments]
+        return [
+            ['get', [$invalidKey]],
+            ['set', [$invalidKey, 'foo']],
+            ['delete', [$invalidKey]],
+            ['getMultiple', [[$invalidKey]]],
+            ['setMultiple', [[$invalidKey => 'foo']]],
+            ['deleteMultiple', [[$invalidKey]]],
+            ['has', [$invalidKey]],
+        ];
+    }
 }

--- a/testing/tests/MemcachedCacheTest.php
+++ b/testing/tests/MemcachedCacheTest.php
@@ -130,4 +130,29 @@ class MemcachedCacheTest extends PHPUnit_Framework_TestCase
             ['has', [$invalidKey]],
         ];
     }
+
+    /**
+     * @dataProvider invalidIterableProvider
+     */
+    public function testInvalidIterableThrowsException($method, $args)
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $logger = new MemoryLogger;
+
+        $memcached = new Memcached;
+        $cache = new MemcachedCache($memcached, 'suffix', $logger);
+
+        $cache->$method(...$args);
+    }
+
+    public function invalidIterableProvider()
+    {
+        // returns [$method, []ofMethodArguments]
+        return [
+            ['getMultiple', ['notAnIterator']],
+            ['setMultiple', ['notAnIterator']],
+            ['deleteMultiple', ['notAnIterator']],
+        ];
+    }
 }

--- a/testing/tests/MemoryCacheTest.php
+++ b/testing/tests/MemoryCacheTest.php
@@ -190,4 +190,25 @@ class MemoryCacheTest extends PHPUnit_Framework_TestCase
             ['has', [$invalidKey]],
         ];
     }
+
+    /**
+     * @dataProvider invalidIterableProvider
+     */
+    public function testInvalidIterableThrowsException($method, $args)
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $cache = new MemoryCache();
+        $cache->$method(...$args);
+    }
+
+    public function invalidIterableProvider()
+    {
+        // returns [$method, []ofMethodArguments]
+        return [
+            ['getMultiple', ['notAnIterator']],
+            ['setMultiple', ['notAnIterator']],
+            ['deleteMultiple', ['notAnIterator']],
+        ];
+    }
 }

--- a/testing/tests/MemoryCacheTest.php
+++ b/testing/tests/MemoryCacheTest.php
@@ -7,11 +7,24 @@
 
 namespace QL\MCP\Cache;
 
+use Psr\SimpleCache\InvalidArgumentException;
 use QL\MCP\Cache\Exception as CacheException;
 use PHPUnit_Framework_TestCase;
 
 class MemoryCacheTest extends PHPUnit_Framework_TestCase
 {
+    /**
+     * @dataProvider invalidKeyDataProvider
+     */
+    public function testInvalidArgumentExceptionThrownOnRequiredMethods($method, $args)
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $cache = new MemoryCache();
+
+        $cache->$method(...$args);
+    }
+
     public function testSettingAKeyAndGetSameKeyResultsInOriginalValue()
     {
         $inputValue = ['myval' => 1];
@@ -34,6 +47,17 @@ class MemoryCacheTest extends PHPUnit_Framework_TestCase
         $this->assertNull($actual);
     }
 
+    public function testGettingKeyThatWasNotSetReturnsDefaultAndNoError()
+    {
+        $inputKey = 'key-with-no-value';
+        $default = 'foo';
+
+        $cache = new MemoryCache;
+
+        $actual = $cache->get($inputKey, $default);
+        $this->assertSame($actual, $default);
+    }
+
     public function testCachingResourceBlowsUp()
     {
         $this->expectException(CacheException::class);
@@ -43,10 +67,127 @@ class MemoryCacheTest extends PHPUnit_Framework_TestCase
         $actual = $cache->set('key', fopen('php://stdout', 'w'));
     }
 
-    public function testGetNotFound()
+    public function testDeleteRemovesItemFromCache()
     {
         $cache = new MemoryCache;
 
-        $this->assertEquals(null, $cache->get('aaaaaaaaa'));
+        $cache->set('foo', 'bar');
+        $this->assertTrue($cache->delete('foo'));
+        $this->assertNull($cache->get('foo'));
+    }
+
+    public function testClear()
+    {
+        $cache = new MemoryCache;
+
+        $cache->set('foo', 'bar');
+        $cache->set('fizz', 'buzz');
+        $this->assertTrue($cache->clear());
+        $this->assertNull($cache->get('foo'));
+        $this->assertNull($cache->get('fizz'));
+    }
+
+    public function testGetMultiple()
+    {
+        $cache = new MemoryCache();
+        $cache->set('foo', 'bar');
+        $cache->set('fizz', 'buzz');
+
+        $return = $cache->getMultiple(new \ArrayIterator(['foo', 'fizz']));
+
+        $this->assertSame('bar', $return['foo']);
+        $this->assertSame('buzz', $return['fizz']);
+    }
+
+    public function testGetMultipleReturnsDefaultsWhenKeyDoesNotExist()
+    {
+        $cache = new MemoryCache();
+
+        $return = $cache->getMultiple(['foo', 'fizz'], 'defaultValue');
+
+        $this->assertSame('defaultValue', $return['foo']);
+        $this->assertSame('defaultValue', $return['fizz']);
+    }
+
+    public function testSetMultiple()
+    {
+        $multipleData = ['foo' => 'bar', 'fizz' => 'buzz'];
+
+        $cache = new MemoryCache();
+        $cache->setMultiple(new \ArrayIterator($multipleData));
+
+        $return = $cache->getMultiple(array_keys($multipleData));
+
+        $this->assertEquals($return, $multipleData);
+    }
+
+    public function testDeleteMultiple()
+    {
+        $multipleData = ['foo' => 'bar', 'fizz' => 'buzz'];
+
+        $cache = new MemoryCache();
+        $cache->setMultiple($multipleData);
+        $cache->deleteMultiple(new \ArrayIterator(array_keys($multipleData)));
+
+        $return = $cache->getMultiple(array_keys($multipleData));
+
+        foreach (array_values($return) as $value) {
+            $this->assertNull($value);
+        }
+    }
+
+    public function testHasKeyReturnsTrueIfKeyExists()
+    {
+        $cache = new MemoryCache();
+        $cache->set('foo', 'bar');
+
+        $this->assertTrue($cache->has('foo'));
+    }
+
+    public function testHasKeyReturnsFalseIfNoKeyExists()
+    {
+        $cache = new MemoryCache();
+
+        $this->assertFalse($cache->has('foo'));
+    }
+
+
+    /**
+     * Testing out that all the multiple gets and setters blow up if passed
+     * a none iterable
+     *
+     * @dataProvider invalidIterableForMultipleCallsDataProvider
+     */
+    public function testMutliCallsErrorOnInvalidArgs($method, $arg)
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $cache = new MemoryCache();
+        $cache->$method($arg);
+    }
+
+    public function invalidIterableForMultipleCallsDataProvider()
+    {
+        return [
+            ['getMultiple', 'singleWord'],
+            ['deleteMultiple', 'singleWord'],
+            ['setMultiple' , 'singleword']
+        ];
+    }
+
+    public function invalidKeyDataProvider()
+    {
+        $invalidKey = '{}()/\\:';
+
+        // returns [$method, []ofMethodArguments]
+        return [
+            ['get', [$invalidKey]],
+            ['set', [$invalidKey, 'foo']],
+            ['delete', [$invalidKey]],
+            ['getMultiple', [[$invalidKey]]],
+            ['setMultiple', [[$invalidKey => 'foo']]],
+            ['deleteMultiple', [[$invalidKey]]],
+            ['has', [$invalidKey]],
+        ];
     }
 }

--- a/testing/tests/PredisCacheTest.php
+++ b/testing/tests/PredisCacheTest.php
@@ -40,7 +40,7 @@ class PredisCacheTest extends PHPUnit_Framework_TestCase
         $inputValue = ['myval' => 1];
         $expected = $inputValue;
 
-        $expectedKey = sprintf('mcp-cache-%s:mykey', CacheInterface::VERSION);
+        $expectedKey = sprintf('mcp-cache-%s.mykey', CacheInterface::VERSION);
 
         $setValue = null;
         $this->predis
@@ -72,7 +72,7 @@ class PredisCacheTest extends PHPUnit_Framework_TestCase
     {
         $inputValue = new DateTime('2015-03-15 4:30:00', new DateTimeZone('UTC'));
 
-        $expectedKey = sprintf('mcp-cache-%s:test', CacheInterface::VERSION);
+        $expectedKey = sprintf('mcp-cache-%s.test', CacheInterface::VERSION);
         $setValue = null;
         $this->predis
             ->shouldReceive('setex')
@@ -92,7 +92,7 @@ class PredisCacheTest extends PHPUnit_Framework_TestCase
 
     public function testSettingNullDeletesKeyInstead()
     {
-        $expectedKey = sprintf('mcp-cache-%s:test', CacheInterface::VERSION);
+        $expectedKey = sprintf('mcp-cache-%s.test', CacheInterface::VERSION);
         $this->predis
             ->shouldReceive('del')
             ->with($expectedKey)
@@ -106,7 +106,7 @@ class PredisCacheTest extends PHPUnit_Framework_TestCase
 
     public function testKeyIsSalted()
     {
-        $expectedKey = sprintf('mcp-cache-%s:test:salty', CacheInterface::VERSION);
+        $expectedKey = sprintf('mcp-cache-%s.test.salty', CacheInterface::VERSION);
 
         $this->predis
             ->shouldReceive('get')
@@ -123,7 +123,7 @@ class PredisCacheTest extends PHPUnit_Framework_TestCase
 
     public function testMaxTTLisUsedIfNoTtlIsProvidedAtRuntime()
     {
-        $expectedKey = sprintf('mcp-cache-%s:test', CacheInterface::VERSION);
+        $expectedKey = sprintf('mcp-cache-%s.test', CacheInterface::VERSION);
         $setValue = null;
 
         $this->predis
@@ -146,7 +146,7 @@ class PredisCacheTest extends PHPUnit_Framework_TestCase
 
     public function testMaxTTLisUsedIfRuntimeExpirationExceedsMaxValue()
     {
-        $expectedKey = sprintf('mcp-cache-%s:test', CacheInterface::VERSION);
+        $expectedKey = sprintf('mcp-cache-%s.test', CacheInterface::VERSION);
         $setValue = null;
         $this->predis
             ->shouldReceive('setex')
@@ -168,7 +168,7 @@ class PredisCacheTest extends PHPUnit_Framework_TestCase
 
     public function testDeleteCallsWithSaltedKey()
     {
-        $expectedKey = sprintf('mcp-cache-%s:test', CacheInterface::VERSION);
+        $expectedKey = sprintf('mcp-cache-%s.test', CacheInterface::VERSION);
 
         $this->predis
             ->shouldReceive('del')
@@ -192,8 +192,8 @@ class PredisCacheTest extends PHPUnit_Framework_TestCase
         $keys = ['foo', 'bar'];
 
         $expectedKeys = [
-            sprintf('mcp-cache-%s:foo', CacheInterface::VERSION),
-            sprintf('mcp-cache-%s:bar', CacheInterface::VERSION)
+            sprintf('mcp-cache-%s.foo', CacheInterface::VERSION),
+            sprintf('mcp-cache-%s.bar', CacheInterface::VERSION)
         ];
 
         $this->predis->shouldReceive('mget')->with($expectedKeys)->andReturn([serialize('fooReturn'), null]);
@@ -209,7 +209,7 @@ class PredisCacheTest extends PHPUnit_Framework_TestCase
         $keys = ['foo'];
 
         $expectedKeys = [
-            sprintf('mcp-cache-%s:foo', CacheInterface::VERSION),
+            sprintf('mcp-cache-%s.foo', CacheInterface::VERSION),
         ];
 
         $this->predis->shouldReceive('mget')->with($expectedKeys)->andReturn([null]);
@@ -228,7 +228,7 @@ class PredisCacheTest extends PHPUnit_Framework_TestCase
         $this->predis->shouldReceive('multi');
         $this->predis->shouldReceive('exec');
 
-        $expectedKey = sprintf('mcp-cache-%s:foo', CacheInterface::VERSION);
+        $expectedKey = sprintf('mcp-cache-%s.foo', CacheInterface::VERSION);
         $setValue = null;
         $this->predis
             ->shouldReceive('setex')
@@ -250,8 +250,8 @@ class PredisCacheTest extends PHPUnit_Framework_TestCase
     {
         $inputValue = ['foo', 'bar'];
         $expectedKeys = [
-            $expectedKey = sprintf('mcp-cache-%s:foo', CacheInterface::VERSION),
-            $expectedKey = sprintf('mcp-cache-%s:bar', CacheInterface::VERSION)
+            $expectedKey = sprintf('mcp-cache-%s.foo', CacheInterface::VERSION),
+            $expectedKey = sprintf('mcp-cache-%s.bar', CacheInterface::VERSION)
         ];
 
         $this->predis->shouldReceive('multi');

--- a/testing/tests/PredisCacheTest.php
+++ b/testing/tests/PredisCacheTest.php
@@ -49,8 +49,9 @@ class PredisCacheTest extends PHPUnit_Framework_TestCase
         $setValue = null;
         $this->predis
             ->shouldReceive('set')
-            ->with($expectedKey, Mockery::on(function($v) use (&$setValue) {
+            ->with($expectedKey, Mockery::on(function ($v) use (&$setValue) {
                 $setValue = $v;
+
                 return true;
             }));
 
@@ -79,8 +80,9 @@ class PredisCacheTest extends PHPUnit_Framework_TestCase
         $setValue = null;
         $this->predis
             ->shouldReceive('setex')
-            ->with($expectedKey, 60, Mockery::on(function($v) use (&$setValue) {
+            ->with($expectedKey, 60, Mockery::on(function ($v) use (&$setValue) {
                 $setValue = $v;
+
                 return true;
             }));
 
@@ -130,8 +132,9 @@ class PredisCacheTest extends PHPUnit_Framework_TestCase
 
         $this->predis
             ->shouldReceive('setex')
-            ->with($expectedKey, 60, Mockery::on(function($v) use (&$setValue) {
+            ->with($expectedKey, 60, Mockery::on(function ($v) use (&$setValue) {
                 $setValue = $v;
+
                 return true;
             }));
 
@@ -151,8 +154,9 @@ class PredisCacheTest extends PHPUnit_Framework_TestCase
         $setValue = null;
         $this->predis
             ->shouldReceive('setex')
-            ->with($expectedKey, 60, Mockery::on(function($v) use (&$setValue) {
+            ->with($expectedKey, 60, Mockery::on(function ($v) use (&$setValue) {
                 $setValue = $v;
+
                 return true;
             }));
 
@@ -233,8 +237,9 @@ class PredisCacheTest extends PHPUnit_Framework_TestCase
         $setValue = null;
         $this->predis
             ->shouldReceive('setex')
-            ->with($expectedKey, 60, Mockery::on(function($v) use (&$setValue) {
+            ->with($expectedKey, 60, Mockery::on(function ($v) use (&$setValue) {
                 $setValue = $v;
+
                 return true;
             }));
 
@@ -248,7 +253,7 @@ class PredisCacheTest extends PHPUnit_Framework_TestCase
 
     public function testDeleteMultipleCallsDeleteWithAllExpectedValues()
     {
-        $inputValue = ['foo' , 'bar'];
+        $inputValue = ['foo', 'bar'];
         $expectedKeys = [
             $expectedKey = sprintf('mcp-cache-%s:foo:1', CacheInterface::VERSION),
             $expectedKey = sprintf('mcp-cache-%s:bar:1', CacheInterface::VERSION)
@@ -259,8 +264,8 @@ class PredisCacheTest extends PHPUnit_Framework_TestCase
 
         foreach ($expectedKeys as $expectedKey) {
             $this->predis
-            ->shouldReceive('del')
-            ->with($expectedKey);
+                ->shouldReceive('del')
+                ->with($expectedKey);
         }
 
         $cache = new PredisCache($this->predis);
@@ -291,6 +296,28 @@ class PredisCacheTest extends PHPUnit_Framework_TestCase
             ['setMultiple', [[$invalidKey => 'foo']]],
             ['deleteMultiple', [[$invalidKey]]],
             ['has', [$invalidKey]],
+        ];
+    }
+
+    /**
+     * @dataProvider invalidIterableProvider
+     */
+    public function testInvalidIterableThrowsException($method, $args)
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $mock = Mockery::mock(Client::class)->shouldIgnoreMissing();
+
+        $cache = new PredisCache($mock);
+        $cache->$method(...$args);
+    }
+
+    public function invalidIterableProvider()
+    {
+        // returns [$method, []ofMethodArguments]
+        return [
+            ['getMultiple', ['notAnIterator']],
+            ['setMultiple', ['notAnIterator']],
+            ['deleteMultiple', ['notAnIterator']],
         ];
     }
 }

--- a/testing/tests/PredisCacheTest.php
+++ b/testing/tests/PredisCacheTest.php
@@ -20,10 +20,6 @@ class PredisCacheTest extends PHPUnit_Framework_TestCase
     public function setUp()
     {
         $this->predis = Mockery::mock(Client::class);
-        $this->predis
-            ->shouldReceive('get')
-            ->with('mcp-cache-' . CacheInterface::VERSION . '-generation')
-            ->andReturn(1);
     }
 
     /**
@@ -44,7 +40,7 @@ class PredisCacheTest extends PHPUnit_Framework_TestCase
         $inputValue = ['myval' => 1];
         $expected = $inputValue;
 
-        $expectedKey = sprintf('mcp-cache-%s:mykey:1', CacheInterface::VERSION);
+        $expectedKey = sprintf('mcp-cache-%s:mykey', CacheInterface::VERSION);
 
         $setValue = null;
         $this->predis
@@ -76,7 +72,7 @@ class PredisCacheTest extends PHPUnit_Framework_TestCase
     {
         $inputValue = new DateTime('2015-03-15 4:30:00', new DateTimeZone('UTC'));
 
-        $expectedKey = sprintf('mcp-cache-%s:test:1', CacheInterface::VERSION);
+        $expectedKey = sprintf('mcp-cache-%s:test', CacheInterface::VERSION);
         $setValue = null;
         $this->predis
             ->shouldReceive('setex')
@@ -96,7 +92,7 @@ class PredisCacheTest extends PHPUnit_Framework_TestCase
 
     public function testSettingNullDeletesKeyInstead()
     {
-        $expectedKey = sprintf('mcp-cache-%s:test:1', CacheInterface::VERSION);
+        $expectedKey = sprintf('mcp-cache-%s:test', CacheInterface::VERSION);
         $this->predis
             ->shouldReceive('del')
             ->with($expectedKey)
@@ -110,7 +106,7 @@ class PredisCacheTest extends PHPUnit_Framework_TestCase
 
     public function testKeyIsSalted()
     {
-        $expectedKey = sprintf('mcp-cache-%s:test:1:salty', CacheInterface::VERSION);
+        $expectedKey = sprintf('mcp-cache-%s:test:salty', CacheInterface::VERSION);
 
         $this->predis
             ->shouldReceive('get')
@@ -127,7 +123,7 @@ class PredisCacheTest extends PHPUnit_Framework_TestCase
 
     public function testMaxTTLisUsedIfNoTtlIsProvidedAtRuntime()
     {
-        $expectedKey = sprintf('mcp-cache-%s:test:1', CacheInterface::VERSION);
+        $expectedKey = sprintf('mcp-cache-%s:test', CacheInterface::VERSION);
         $setValue = null;
 
         $this->predis
@@ -150,7 +146,7 @@ class PredisCacheTest extends PHPUnit_Framework_TestCase
 
     public function testMaxTTLisUsedIfRuntimeExpirationExceedsMaxValue()
     {
-        $expectedKey = sprintf('mcp-cache-%s:test:1', CacheInterface::VERSION);
+        $expectedKey = sprintf('mcp-cache-%s:test', CacheInterface::VERSION);
         $setValue = null;
         $this->predis
             ->shouldReceive('setex')
@@ -172,7 +168,7 @@ class PredisCacheTest extends PHPUnit_Framework_TestCase
 
     public function testDeleteCallsWithSaltedKey()
     {
-        $expectedKey = sprintf('mcp-cache-%s:test:1', CacheInterface::VERSION);
+        $expectedKey = sprintf('mcp-cache-%s:test', CacheInterface::VERSION);
 
         $this->predis
             ->shouldReceive('del')
@@ -186,8 +182,7 @@ class PredisCacheTest extends PHPUnit_Framework_TestCase
 
     public function testClearSetsCacheGenerationToCache()
     {
-        $this->predis->shouldReceive('set')->with(PredisCache::GENERATION_KEY, 2);
-
+        $this->predis->shouldReceive('flushdb')->andReturn(true);
         $cache = new PredisCache($this->predis);
         $cache->clear();
     }
@@ -197,8 +192,8 @@ class PredisCacheTest extends PHPUnit_Framework_TestCase
         $keys = ['foo', 'bar'];
 
         $expectedKeys = [
-            sprintf('mcp-cache-%s:foo:1', CacheInterface::VERSION),
-            sprintf('mcp-cache-%s:bar:1', CacheInterface::VERSION)
+            sprintf('mcp-cache-%s:foo', CacheInterface::VERSION),
+            sprintf('mcp-cache-%s:bar', CacheInterface::VERSION)
         ];
 
         $this->predis->shouldReceive('mget')->with($expectedKeys)->andReturn([serialize('fooReturn'), null]);
@@ -214,7 +209,7 @@ class PredisCacheTest extends PHPUnit_Framework_TestCase
         $keys = ['foo'];
 
         $expectedKeys = [
-            sprintf('mcp-cache-%s:foo:1', CacheInterface::VERSION),
+            sprintf('mcp-cache-%s:foo', CacheInterface::VERSION),
         ];
 
         $this->predis->shouldReceive('mget')->with($expectedKeys)->andReturn([null]);
@@ -233,7 +228,7 @@ class PredisCacheTest extends PHPUnit_Framework_TestCase
         $this->predis->shouldReceive('multi');
         $this->predis->shouldReceive('exec');
 
-        $expectedKey = sprintf('mcp-cache-%s:foo:1', CacheInterface::VERSION);
+        $expectedKey = sprintf('mcp-cache-%s:foo', CacheInterface::VERSION);
         $setValue = null;
         $this->predis
             ->shouldReceive('setex')
@@ -255,8 +250,8 @@ class PredisCacheTest extends PHPUnit_Framework_TestCase
     {
         $inputValue = ['foo', 'bar'];
         $expectedKeys = [
-            $expectedKey = sprintf('mcp-cache-%s:foo:1', CacheInterface::VERSION),
-            $expectedKey = sprintf('mcp-cache-%s:bar:1', CacheInterface::VERSION)
+            $expectedKey = sprintf('mcp-cache-%s:foo', CacheInterface::VERSION),
+            $expectedKey = sprintf('mcp-cache-%s:bar', CacheInterface::VERSION)
         ];
 
         $this->predis->shouldReceive('multi');

--- a/testing/tests/PredisCacheTest.php
+++ b/testing/tests/PredisCacheTest.php
@@ -20,6 +20,10 @@ class PredisCacheTest extends PHPUnit_Framework_TestCase
     public function setUp()
     {
         $this->predis = Mockery::mock(Client::class);
+        $this->predis
+            ->shouldReceive('get')
+            ->with('mcp-cache-generation-' . CacheInterface::VERSION)
+            ->andReturn(1);
     }
 
     public function testSettingAKeyAndGetSameKeyResultsInOriginalValue()
@@ -27,7 +31,7 @@ class PredisCacheTest extends PHPUnit_Framework_TestCase
         $inputValue = ['myval' => 1];
         $expected = $inputValue;
 
-        $expectedKey = sprintf('mcp-cache-%s:mykey', CacheInterface::VERSION);
+        $expectedKey = sprintf('mcp-cache-%s:mykey:1', CacheInterface::VERSION);
 
         $setValue = null;
         $this->predis
@@ -58,7 +62,7 @@ class PredisCacheTest extends PHPUnit_Framework_TestCase
     {
         $inputValue = new DateTime('2015-03-15 4:30:00', new DateTimeZone('UTC'));
 
-        $expectedKey = sprintf('mcp-cache-%s:test', CacheInterface::VERSION);
+        $expectedKey = sprintf('mcp-cache-%s:test:1', CacheInterface::VERSION);
         $setValue = null;
         $this->predis
             ->shouldReceive('setex')
@@ -77,7 +81,7 @@ class PredisCacheTest extends PHPUnit_Framework_TestCase
 
     public function testSettingNullDeletesKeyInstead()
     {
-        $expectedKey = sprintf('mcp-cache-%s:test', CacheInterface::VERSION);
+        $expectedKey = sprintf('mcp-cache-%s:test:1', CacheInterface::VERSION);
         $this->predis
             ->shouldReceive('del')
             ->with($expectedKey)
@@ -91,7 +95,7 @@ class PredisCacheTest extends PHPUnit_Framework_TestCase
 
     public function testKeyIsSalted()
     {
-        $expectedKey = sprintf('mcp-cache-%s:test:salty', CacheInterface::VERSION);
+        $expectedKey = sprintf('mcp-cache-%s:test:1:salty', CacheInterface::VERSION);
 
         $this->predis
             ->shouldReceive('get')
@@ -108,7 +112,7 @@ class PredisCacheTest extends PHPUnit_Framework_TestCase
 
     public function testMaxTTLisUsedIfNoTtlIsProvidedAtRuntime()
     {
-        $expectedKey = sprintf('mcp-cache-%s:test', CacheInterface::VERSION);
+        $expectedKey = sprintf('mcp-cache-%s:test:1', CacheInterface::VERSION);
         $setValue = null;
 
         $this->predis
@@ -130,7 +134,7 @@ class PredisCacheTest extends PHPUnit_Framework_TestCase
 
     public function testMaxTTLisUsedIfRuntimeExpirationExceedsMaxValue()
     {
-        $expectedKey = sprintf('mcp-cache-%s:test', CacheInterface::VERSION);
+        $expectedKey = sprintf('mcp-cache-%s:test:1', CacheInterface::VERSION);
         $setValue = null;
         $this->predis
             ->shouldReceive('setex')


### PR DESCRIPTION
Updating Cache's to PSR 16 fixes #1 

`PSR16` and the `CacheInterface` are compatible so I deprecated the `CacheInterface` for removal in the next major release but all the caches implement both for backwards compatibility.

Still working on the rest of the caches and their tests but they should go fairly quickly now.

- [x] `MemoryCache`
- [x] `PredisCache`
- [x] `MemcachedCache`
- [x] `MemcacheCache`
- [x] `APCCache`